### PR TITLE
Perf tweaks

### DIFF
--- a/Sources/UniqueID/Time.swift
+++ b/Sources/UniqueID/Time.swift
@@ -29,11 +29,13 @@ internal func _get_system_timestamp() -> UInt64 {
   if #available(macOS 10.12, *) {
     var time = timespec()
     clock_gettime(CLOCK_REALTIME, &time)
-    timestamp = (UInt64(time.tv_sec) &* 10_000_000) &+ (UInt64(time.tv_nsec) / 100)
+    timestamp =
+      (UInt64(bitPattern: Int64(time.tv_sec)) &* 10_000_000) &+ (UInt64(bitPattern: Int64(time.tv_nsec)) / 100)
   } else {
     var time = timeval()
     gettimeofday(&time, nil)
-    timestamp = (UInt64(time.tv_sec) &* 10_000_000) &+ (UInt64(time.tv_usec) &* 10)
+    timestamp =
+      (UInt64(bitPattern: Int64(time.tv_sec)) &* 10_000_000) &+ (UInt64(bitPattern: Int64(time.tv_usec)) &* 10)
   }
   return timestamp & 0x0FFF_FFFF_FFFF_FFFF
 }

--- a/Sources/UniqueID/UniqueID+v6.swift
+++ b/Sources/UniqueID/UniqueID+v6.swift
@@ -71,9 +71,6 @@ internal var _uuidv6GeneratorState = UUIDv6GeneratorState()
     guard pthread_mutexattr_init(&attrs) == 0 else { fatalError("Failed to create pthread_mutexattr_t") }
     // Use adaptive spinning before calling in to the kernel (GNU extension).
     let _ = pthread_mutexattr_settype(&attrs, CInt(PTHREAD_MUTEX_ADAPTIVE_NP))
-    // Bump lock-holder's priority if waited on by higher-priority threads.
-    // Prevents priority inversion.
-    let _ = pthread_mutexattr_setprotocol(&attrs, CInt(PTHREAD_PRIO_INHERIT))
     guard pthread_mutex_init(mutex, &attrs) == 0 else { fatalError("Failed to create pthread_mutex_t") }
     pthread_mutexattr_destroy(&attrs)
 


### PR DESCRIPTION
1. Tweak timestamp generation to avoid implicit traps if the system returns a negative timestamp. This results in better inlining.
2. Tweak random UUID generation so the `withUnsafeMutableBytes` closure does not get outlined (I hate that the compiler does this! Gah! Why?!)
3. Disable priority inheritance on Linux.

These are mostly minor, but priority inheritance can have more significant overheads so is worth disabling unless/until we have a reason to change it.