### PR TITLE
[Won't merge] Use stdlib random API directly via a C shim

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,8 +43,10 @@ let package = Package(
         targets: ["UniqueID"]),
     ],
     targets: [
+      .target(name: "Swift_UniqueID_RuntimeShims"),
       .target(
         name: "UniqueID",
+        dependencies: ["Swift_UniqueID_RuntimeShims"],
         swiftSettings: settings),
       .testTarget(
         name: "UniqueIDTests",

--- a/Sources/Swift_UniqueID_RuntimeShims/dummy.c
+++ b/Sources/Swift_UniqueID_RuntimeShims/dummy.c
@@ -1,0 +1,15 @@
+// Copyright The swift-UniqueID Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "shims.h"

--- a/Sources/Swift_UniqueID_RuntimeShims/include/shims.h
+++ b/Sources/Swift_UniqueID_RuntimeShims/include/shims.h
@@ -1,0 +1,21 @@
+// Copyright The swift-UniqueID Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef Swift_UniqueID_RuntimeShims_h
+#define Swift_UniqueID_RuntimeShims_h
+
+#include "stddef.h"
+void swift_stdlib_random(void*, size_t);
+
+#endif /* Swift_UniqueID_RuntimeShims_h */


### PR DESCRIPTION
Use the standard library's random API via a C shim, so we're not limited to 8 bytes per syscall.

Technically, the compiler headers [say](https://github.com/apple/swift/blob/687cee9bfa213de235236d7510bd371856735b90/stdlib/public/SwiftShims/Visibility.h#L245):

```
/// SWIFT_RUNTIME_STDLIB_API functions are called by compiler-generated code
/// or by @inlinable Swift code.
/// Such functions must be exported and must be supported forever as API.
/// The function name should be prefixed with `swift_`.
```

So... it's not unsafe or unsupported ("must be supported forever"). 
But it's hacky.

It's interesting for benchmarks, but I don't think this should be merged. We should fix the standard library instead.